### PR TITLE
Fixed budget calculation for WebPageTest

### DIFF
--- a/examples/tests.json
+++ b/examples/tests.json
@@ -4,7 +4,7 @@
     "webPageTestApiEndpoint": "https://webpagetest.org",
     "psiApiKey": "TEST_APIKEY",
     "gcpKeyFilePath": "tmp/gcp-service-account.json",
-    "gcpProjectId": "",
+    "gcpProjectId": ""
   },
   "tests": [
     {
@@ -38,7 +38,7 @@
         }
       },
       "budgets": {
-        "dataSource": "webpagetest",
+        "metricPath": "webpagetest.metrics.[METRIC_NAME]",
         "budget": {
           "FirstContentfulPaint": 1500,
           "FirstMeaningfulPaint": 2000,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "awp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "AutoWebPerf",
   "main": "index.js",
   "scripts": {

--- a/src/awp-core.js
+++ b/src/awp-core.js
@@ -431,13 +431,13 @@ class AutoWebPerf {
       // Collect errors from all gatherers.
       newResult.errors = result.errors.concat(this.getOverallErrors(newResult));
 
+      // Update overall status.
+      newResult.status =  this.getOverallStatus(statuses);
+
       // After retrieving the result.
       extResponse = this.runExtensions(extensions, 'afterRetrieve',
           {result: newResult}, options);
       newResult.errors = newResult.errors.concat(extResponse.errors);
-
-      // Update overall status.
-      newResult.status =  this.getOverallStatus(statuses);
 
       this.log(`Retrieve: overall status=${newResult.status}`);
       this.logDebug('AutoWebPerf::retrieve, statuses=\n', statuses);


### PR DESCRIPTION
The issue was due to the incorrect order of getting the overall status in a Result and running "afterRetrieve" extensions. When the Budget extension ran before getting the overall status, it accidentally ignored the result when the status is still "Submitted".