### PR TITLE
Fixed budget calculation for WebPageTest and GA tracking

### DIFF
--- a/examples/tests.json
+++ b/examples/tests.json
@@ -4,7 +4,7 @@
     "webPageTestApiEndpoint": "https://webpagetest.org",
     "psiApiKey": "TEST_APIKEY",
     "gcpKeyFilePath": "tmp/gcp-service-account.json",
-    "gcpProjectId": "",
+    "gcpProjectId": ""
   },
   "tests": [
     {

--- a/src/awp-core.js
+++ b/src/awp-core.js
@@ -431,13 +431,13 @@ class AutoWebPerf {
       // Collect errors from all gatherers.
       newResult.errors = result.errors.concat(this.getOverallErrors(newResult));
 
+      // Update overall status.
+      newResult.status =  this.getOverallStatus(statuses);
+
       // After retrieving the result.
       extResponse = this.runExtensions(extensions, 'afterRetrieve',
           {result: newResult}, options);
       newResult.errors = newResult.errors.concat(extResponse.errors);
-
-      // Update overall status.
-      newResult.status =  this.getOverallStatus(statuses);
 
       this.log(`Retrieve: overall status=${newResult.status}`);
       this.logDebug('AutoWebPerf::retrieve, statuses=\n', statuses);

--- a/src/extensions/googlesheets-extension.js
+++ b/src/extensions/googlesheets-extension.js
@@ -60,7 +60,7 @@ class GoogleSheetsExtension extends Extension {
     this.userTimeZone = GoogleSheetsHelper.getUserTimeZone();
     this.clientEmail = GoogleSheetsHelper.getClientEmail();
     this.spreadsheetId = GoogleSheetsHelper.getSpreadsheetId();
-    this.awpVersion = config.awpVersion || 'awp-dev';
+    this.awpVersion = config.awpVersion || 'awp';
     this.gaAccount = config.gaAccount;
     this.locations = null;
 
@@ -244,7 +244,7 @@ class GoogleSheetsExtension extends Extension {
    */
   trackAction(trackingType, sheetId, result) {
     let testedUrl = result.url || result.origin || 'No given URL';
-    let referral = this.awpVersion ? `${this.awpVersion} - ` : '';
+    let referral = this.awpVersion || 'awp';
     let url;
 
     // FIXME: Load the list of data sources from awpConfig instead of hardcoded.
@@ -255,7 +255,9 @@ class GoogleSheetsExtension extends Extension {
         activeDataSources.push(dataSource);
       }
     });
-    referral += activeDataSources.join(',');
+    if (activeDataSources.length) {
+      referral += '/' + activeDataSources.join('/');
+    }
 
     // Record legacy GA event.
     if (this.isSendTrackEvent) {

--- a/src/gatherers/webpagetest.js
+++ b/src/gatherers/webpagetest.js
@@ -105,7 +105,7 @@ class WebPageTestGatherer extends Gatherer {
       'VisualComplete': 'data.median.firstView.visualComplete',
       'SpeedIndex': 'data.median.firstView.SpeedIndex',
       'LoadEvent': 'data.median.firstView.loadTime',
-      'TTIMeasurementEnd': 'data.median.firstView.TTIMeasurementEnd',
+      'TimeToInteractive': 'data.median.firstView.TTIMeasurementEnd',
       'DOMContentLoaded': 'data.median.firstView.domContentLoadedEventStart',
 
       // WebPageTest Resource Count metrics


### PR DESCRIPTION
- Fixed afterRetrieve order for webpagetest async logic.
- Fixed TTI for WPT gatherer.
- Updated referral path for GA tracking.

Tested on awp-staging.