### PR TITLE
Fixed PSI gatherer when there's no CrUX data from the API response.

### DIFF
--- a/src/gatherers/psi.js
+++ b/src/gatherers/psi.js
@@ -230,9 +230,9 @@ class PSIGatherer extends Gatherer {
   }
 
   preprocessData(json, dataSource) {
-    if (dataSource === 'crux') {
+    if (dataSource === 'crux' && json.loadingExperience) {
       let processedLoadingExperience = {};
-      let expMetrics = json.loadingExperience.metrics;
+      let expMetrics = json.loadingExperience.metrics || {};
       let expMetricsToProcess = {
         lcp: expMetrics.LARGEST_CONTENTFUL_PAINT_MS,
         fid: expMetrics.FIRST_INPUT_DELAY_MS,


### PR DESCRIPTION
When the CrUX data is empty at the json.loadingExperience.metrics, it throws errors when fetching the metric values. Added a check to prevent this edge case.