### PR TITLE
Added CSV connector and fixed multi connector implementation

### DIFF
--- a/examples/awp-config-multi-connectors.json
+++ b/examples/awp-config-multi-connectors.json
@@ -1,19 +1,15 @@
 {
-  "connector": {
-    "tests": "json",
-    "results": "bigquery"
+  "tests": {
+    "connector": "csv",
+    "path": "examples/tests.csv"
+  },
+  "results": {
+    "connector": "json",
+    "path": "tmp/results.json",
+    "appendResults": false
   },
   "helper": "node",
   "extensions": ["budgets"],
-  "json": {
-    "testsPath": "examples/tests.json",
-    "resultsPath": "tmp/results.json"
-  },
-  "bigquery": {
-    "testsPath": "path/to/table",
-    "resultsPath": "path/to/table",
-    "overrideResults": true
-  },
   "verbose": true,
   "debug": false
 }

--- a/examples/awp-config.json
+++ b/examples/awp-config.json
@@ -1,5 +1,13 @@
 {
-  "connector": "json",
+  "tests": {
+    "connector": "json",
+    "path": "examples/tests.json"
+  },
+  "results": {
+    "connector": "json",
+    "path": "tmp/results.json",
+    "appendResults": true
+  },
   "helper": "node",
   "extensions": ["budgets"],
   "json": {

--- a/examples/tests.csv
+++ b/examples/tests.csv
@@ -1,0 +1,2 @@
+label,url,psi.settings.strategy
+web.dev,https://web.dev,mobile

--- a/integration/appscript-bundle.test.js
+++ b/integration/appscript-bundle.test.js
@@ -54,9 +54,14 @@ describe('AWP bundle for AppScript', () => {
       'Results-2': initFakeSheet(fakeSheetData.fakeEmptyResultsSheetData),
     };
 
-    awp = new AutoWebPerf({
-      connector: 'AppScript',
-      helper: 'AppScript',
+    let awpConfig = {
+      tests: {
+        connector: 'appscript',
+      },
+      results: {
+        connector: 'appscript',
+      },
+      helper: 'appscript',
       gatherers: ['webpagetest', 'psi', 'cruxapi', 'cruxbigquery'],
       extensions: [
         'budgets',
@@ -116,12 +121,6 @@ describe('AWP bundle for AppScript', () => {
           skipRows: 2,
           skipColumns: 0,
         }],
-        // validationsMaps: [{
-        //   targetTab: 'Tests-1',
-        //   targetProperty: 'webpagetest.settings.location',
-        //   validationTab: 'Locations',
-        //   validationProperty: 'name',
-        // }],
         // For GA tracking
         gaAccount: 'UA-123456789-1',
         awpVersion: 'awp-dev',
@@ -133,7 +132,9 @@ describe('AWP bundle for AppScript', () => {
       batchUpdateBuffer: 10,
       verbose: false,
       debug: false,
-    });
+    };
+
+    awp = new AutoWebPerf(awpConfig);
   });
 
   it('creates AWP instance', () => {
@@ -141,7 +142,7 @@ describe('AWP bundle for AppScript', () => {
   });
 
   it('initializes AWP for AppScript via connector init()', () => {
-    awp.connector.apiHelper.fetch = () => {
+    awp.connector.apiHandler.fetch = () => {
       return {
         statusCode: 200,
         body: JSON.stringify({
@@ -445,7 +446,7 @@ describe('AWP bundle for AppScript', () => {
     ];
     fakeSheets['Results-1'] = initFakeSheet(resultsData);
 
-    awp.connector.apiHelper.fetch = () => {
+    awp.connector.apiHandler.fetch = () => {
       return {
         statusCode: 200,
         body: fs.readFileSync('./test/fakedata/wpt-retrieve-response.json')
@@ -476,7 +477,7 @@ describe('AWP bundle for AppScript', () => {
     ];
     fakeSheets['Results-1'] = initFakeSheet(resultsData);
 
-    awp.connector.apiHelper.fetch = () => {
+    awp.connector.apiHandler.fetch = () => {
       return {
         statusCode: 400,
         statusText: 'Some error',
@@ -516,7 +517,7 @@ describe('AWP bundle for AppScript', () => {
     ];
     fakeSheets['System'] = initFakeSheet(systemData);
 
-    awp.connector.apiHelper.fetch = () => {
+    awp.connector.apiHandler.fetch = () => {
       return {
         statusCode: 200,
         body: fs.readFileSync('./test/fakedata/wpt-retrieve-response.json')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1590,6 +1590,11 @@
         }
       }
     },
+    "csv-parse": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.12.0.tgz",
+      "integrity": "sha512-wPQl3H79vWLPI8cgKFcQXl0NBgYYEqVnT1i6/So7OjMpsI540oD7p93r3w6fDSyPvwkTepG05F69/7AViX2lXg=="
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -4161,6 +4166,11 @@
       "requires": {
         "minimist": "^1.2.0"
       }
+    },
+    "jsonexport": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsonexport/-/jsonexport-3.0.1.tgz",
+      "integrity": "sha512-lxDoAZxmWDt1wa4S75CUYe/ZASdmOYyhV7iYbF4npTWxrDv19ofZpJMGbt20W5Orx0hYuid65zGHpt6rRW0Z3A=="
     },
     "jsonfile": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "AutoWebPerf",
   "main": "index.js",
   "scripts": {
@@ -22,9 +22,11 @@
   "dependencies": {
     "@babel/core": "^7.8.3",
     "@google-cloud/bigquery": "^4.7.0",
+    "csv-parse": "^4.12.0",
     "dayjs": "^1.8.19",
     "fs": "0.0.1-security",
     "fs-extra": "^8.1.0",
+    "jsonexport": "^3.0.1",
     "minimist": "^1.2.3",
     "path": "^0.12.7",
     "request": "^2.88.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,7 +17,10 @@ export default [{
     commonjs({
       ignore: [
         'sync-request',
+        'fs-extra',
+        'path',
         './connectors/json-connector',
+        './connectors/csv-connector',
         './helpers/node-helper',
         '@google-cloud/bigquery',
         '../../test/fakedata/psi-response.json', //FIXME: use exclude.

--- a/src/cli.js
+++ b/src/cli.js
@@ -62,7 +62,7 @@ Examples:
   ./awp run --tests=examples/tests-cruxbigquery.json --results=tmp/results.json --runByBatch --envVars=gcpKeyFilePath=KEY_PATH,gcpProjectId=PROJECT_ID
 
   # Run with multiple connectors: tests from local JSON and writes results to BigQuery.
-  ./awp run --tests=json:examples/tests.json --results=bigquery:path/to/table --envVars=psiApiKey=SAMPLE_APIKEY
+  ./awp run --tests=csv:examples/tests.csv --results=json:tmp/results.json --envVars=psiApiKey=SAMPLE_APIKEY
 
   # Run tests with budget extension
   ./awp run --tests=examples/tests.json --results=tmp/results.json --extensions=budgets
@@ -98,7 +98,7 @@ async function begin() {
   let testsPath = argv['tests'];
   let resultsPath = argv['results'];
   let config = argv['config'];
-  let overrideResults = argv['append-results'] ? false : true;
+  let appendResults = argv['append-results'];
   let gatherers = argv['gatherers'] ? argv['gatherers'].split(',') : null;
   let extensions = argv['extensions'] ? argv['extensions'].split(',') : [];
   let runByBatch = argv['runByBatch'] ?  true : false;
@@ -137,9 +137,14 @@ async function begin() {
 
     // Construct overall AWP config and individual connector's config.
     awpConfig = {
-      connector: {
-        tests: testsConnector,
-        results: resultsConnector,
+      tests: {
+        connector: testsConnector,
+        path: testsPath,
+      },
+      results: {
+        connector: resultsConnector,
+        path: resultsPath,
+        appendResults: appendResults,
       },
       helper: 'node',
       gatherers: gatherers || ['webpagetest', 'psi', 'cruxbigquery', 'cruxapi'],
@@ -148,14 +153,6 @@ async function begin() {
       verbose: verbose,
       debug: debug,
     };
-
-    let connectorConfig = {
-      testsPath: testsPath,
-      resultsPath: resultsPath,
-      overrideResults: overrideResults,
-    };
-    awpConfig[testsConnector] = connectorConfig;
-    awpConfig[resultsConnector] = connectorConfig;
   }
 
   if (verbose) {

--- a/src/connectors/appscript-connector.js
+++ b/src/connectors/appscript-connector.js
@@ -41,15 +41,15 @@ class AppScriptConnector extends Connector {
    * singleton ApiHandler instance. The config object is a sub-property from
    * the awpConfig object at the top level.
    * @param  {Object} config The config object for initializing this connector.
-   * @param  {Object} apiHelper ApiHandler instance initialized in awp-core.
+   * @param  {Object} apiHandler ApiHandler instance initialized in awp-core.
    */
-  constructor(config, apiHelper) {
+  constructor(config, apiHandler) {
     super();
     assert(config.tabs, 'tabs is missing in config.');
     assert(config.defaultTestsTab, 'defaultTestsTab is missing in config.');
     assert(config.defaultResultsTab, 'defaultResultsTab is missing in config.');
 
-    this.apiHelper = apiHelper;
+    this.apiHandler = apiHandler;
     this.locationApiEndpoint = 'http://www.webpagetest.org/getLocations.php?f=json&k=A';
     this.activeSpreadsheet = SpreadsheetApp.getActive();
     this.defaultTestsTab = config.defaultTestsTab;
@@ -483,7 +483,7 @@ class AppScriptConnector extends Connector {
     let sheet = this.getSheet('locationsTab');
 
     // Get new locations from remote API.
-    let response = this.apiHelper.fetch(this.locationApiEndpoint);
+    let response = this.apiHandler.fetch(this.locationApiEndpoint);
     if(response.statusCode == 200) {
       let json = JSON.parse(response.body);
 

--- a/src/connectors/connector.js
+++ b/src/connectors/connector.js
@@ -15,7 +15,14 @@
  */
 
 class Connector {
-  constructor(config, apiHandler) {}
+  constructor(config, apiHandler) {
+    config = config || {};
+    this.apiHandler = apiHandler;
+    this.testsPath = config.testsPath;
+    this.resultsPath = config.resultsPath;
+    this.verbose = config.verbose;
+    this.debug = config.debug;
+  }
   getEnvVars() {}
   getTestList(options) {}
   updateTestList(newTests, options) {}

--- a/src/connectors/csv-connector.js
+++ b/src/connectors/csv-connector.js
@@ -1,0 +1,236 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const fs = require('fs-extra');
+const path = require('path');
+const parse = require('csv-parse/lib/sync');
+const jsonexport = require('jsonexport');
+const assert = require('../utils/assert');
+const setObject = require('../utils/set-object');
+const Connector = require('./connector');
+
+/**
+ * the connector handles read and write actions with local JSON files as a data
+ * store. This connector works together with `src/helpers/node-helper.js`.
+ */
+class CSVConnector extends Connector {
+  constructor(config, apiHelper) {
+    super(config, apiHelper);
+  }
+
+  /**
+   * Reading CSV file and converts to nested JSON objects.
+   * @param  {string} filename
+   * @return {Object} JSON object with nested properties.
+   */
+  readCsv(filename) {
+    if (this.debug) {
+      console.log('reading csv file: ' + filename);
+    }
+
+    if (fs.existsSync(filename)) {
+      let fileContent = fs.readFileSync(filename);
+      let data = parse(fileContent, {columns: true});
+      return this.convertJson(data);
+
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Writing objects to a CSV file.
+   * @param  {string} filename
+   */
+  writeCsv(filename, data) {
+    if (this.debug) {
+      console.log('writing to csv file: ' + filename);
+    }
+
+    jsonexport(data, function(err, csv){
+      if (err) {
+        throw new Error(err);
+      }
+      fs.writeFileSync(filename, csv);
+    });
+  }
+
+  /**
+   * Convert flat object to nested properties.
+   * @param  {Array<Object>} Array of objects.
+   * @return {Array<Object>} JSON object with nested properties.
+   */
+  convertJson(data) {
+    (data || []).forEach(item => {
+      Object.keys(item).forEach(key => {
+        if(key.match(/\./)) {
+          setObject(item, key, item[key]);
+          delete item[key];
+        }
+      })
+    });
+    return data;
+  }
+
+  /**
+   * Get the Test list.
+   * @return {Array<Object>} Array of Test objects.
+   */
+  getTests() {
+    if (this.tests) return this.tests;
+    assert(this.testsPath, 'testsPath is not defined.');
+
+    if (!fs.existsSync(this.testsPath)) {
+      throw new Error(`File "${this.testsPath}" not found.`);
+    }
+
+    let tests = this.readCsv(this.testsPath);
+    assert(tests && tests.length > 0, `No tests found in ${this.testsPath}.`);
+    return tests;
+  }
+
+  /**
+   * Get the Result list.
+   * @return {Array<Object>} Array of Result objects.
+   */
+  getResults() {
+    if (this.results) return this.results;
+    assert(this.resultsPath, 'resultsPath is not defined.');
+
+    let results = this.readCsv(this.resultsPath);
+    return results || [];
+  }
+
+  /**
+   * Return EnvVars set.
+   * @return {Object} EnvVars object.
+   */
+  getEnvVars() {
+    // FIXME: CSV Connector doesn't support embedded EnvVars with the tests list.
+    return {};
+  }
+
+  /**
+   * Get all tests.
+   * @param  {Object} options
+   * @return {Array<Object>} Array of Test objects.
+   */
+  getTestList(options) {
+    let tests = this.getTests();
+
+    // Manually add index to all test objects.
+    let index = 0;
+    tests.forEach(test => {
+      test.csv = {
+        index: index++,
+      }
+    });
+
+    return tests;
+  }
+
+  /**
+   * Update tests with the given new test objects.
+   * @param {Array<Object>} Array of new Test objects.
+   * @param  {Object} options
+   */
+  updateTestList(newTests, options) {
+    let filepath = path.resolve(this.testsPath);
+    let tests = this.getTestList();
+
+    let rowIndexToTests = {};
+    newTests.forEach(newTest => {
+      rowIndexToTests[newTest.csv.index] = newTest;
+    });
+
+    let index = 0;
+    let testsToUpdate = [];
+    tests.forEach(test => {
+      test = rowIndexToTests[index] || test;
+      delete test.csv;
+      testsToUpdate.push(test);
+      index++;
+    })
+
+    this.writeCsv(this.testsPath, tests);
+
+    // Reset the tests cache.
+    this.tests = null;
+  }
+
+  /**
+   * Get all results.
+   * @param  {Object} options
+   * @return {Array<Object>} Array of Result objects.
+   */
+  getResultList(options) {
+    let results;
+    try {
+      results = this.getResults();
+
+    } catch (error) {
+      console.log(error);
+
+    } finally {
+      return results || [];
+    }
+  }
+
+  /**
+   * Append results to the existing result list.
+   * @param {Array<Object>} newResults Array of new Result objects.
+   * @param {Object} options
+   */
+  appendResultList(newResults, options) {
+    let results = this.getResultList();
+
+    if (this.debug) {
+      console.log(`Appending ${newResults.length} results to the existing ` +
+          `file at ${this.resultsPath}`);
+    }
+    this.writeCsv(this.resultsPath, results.concat(newResults));
+
+    // Reset the results json cache.
+    this.results = null;
+  }
+
+  /**
+   * Override results to the existing result list.
+   * @param {Array<Object>} newResults Array of new Result objects.
+   * @param {Object} options
+   */
+  updateResultList(newResults, options) {
+    let results = this.getResultList();
+    let idToResults = {};
+
+    newResults.forEach(result => {
+      idToResults[result.id] = result;
+    });
+
+    results = results.map(result => {
+      return idToResults[result.id] || result;
+    });
+
+    this.writeCsv(this.resultsPath, results);
+
+    // Reset the results json cache.
+    this.results = null;
+  }
+}
+
+module.exports = CSVConnector;

--- a/src/connectors/json-connector.js
+++ b/src/connectors/json-connector.js
@@ -24,26 +24,26 @@ const Connector = require('./connector');
 /**
  * the connector handles read and write actions with local JSON files as a data
  * store. This connector works together with `src/helpers/node-helper.js`.
+ * @param  {Object} config The config object for initializing this connector.
+ * @param  {Object} apiHandler ApiHandler instance initialized in awp-core.
  */
 class JSONConnector extends Connector {
-  constructor(config) {
-    super();
-    this.testsPath = config.testsPath;
-    this.resultsPath = config.resultsPath;
-    this.testsJson = null;
-    this.resultsJson = null;
+  constructor(config, apiHandler) {
+    super(config, apiHandler);
+    this.tests = null;
+    this.results = null;
   }
 
   getTestsJson() {
-    if (this.testsJson) return this.testsJson;
-    assert(this.testsPath, 'testsPath is missing in config.');
+    if (this.tests) return this.tests;
+    assert(this.testsPath, 'testsPath is not defined.');
 
     return JSON.parse(fse.readFileSync(path.resolve(`${this.testsPath}`)));
   }
 
   getResultsJson() {
-    if (this.resultsJson) return this.resultsJson;
-    assert(this.resultsPath, 'resultsPath is missing in config.');
+    if (this.results) return this.results;
+    assert(this.resultsPath, 'resultsPath is not defined.');
 
     let filepath = path.resolve(`${this.resultsPath}`);
     if (fse.existsSync(filepath)) {
@@ -57,23 +57,23 @@ class JSONConnector extends Connector {
   }
 
   getEnvVars() {
-    let testsJson = this.getTestsJson();
-    let envVars = (testsJson || {}).envVars;
+    let tests = this.getTestsJson();
+    let envVars = (tests || {}).envVars;
     return envVars;
   }
 
   getTestList(options) {
-    let testsJson = this.getTestsJson();
+    let tests = this.getTestsJson();
 
     // Manually add index to all test objects.
     let index = 0;
-    testsJson.tests.forEach(test => {
+    tests.tests.forEach(test => {
       test.json = {
         index: index++,
       }
     });
 
-    return testsJson.tests;
+    return tests.tests;
   }
 
   updateTestList(newTests) {
@@ -102,14 +102,14 @@ class JSONConnector extends Connector {
       }, null, 2));
 
     // Reset the tests json cache.
-    this.testsJson = null;
+    this.tests = null;
   }
 
   getResultList(options) {
     let results = [];
     try {
-      let resultsJson = this.getResultsJson();
-      results = resultsJson.results || [];
+      let json = this.getResultsJson();
+      results = json.results || [];
 
     } catch (error) {
       console.log(error);
@@ -128,7 +128,7 @@ class JSONConnector extends Connector {
       }, null, 2));
 
     // Reset the results json cache.
-    this.resultsJson = null;
+    this.results = null;
   }
 
   updateResultList(newResults, options) {
@@ -150,7 +150,7 @@ class JSONConnector extends Connector {
       }, null, 2));
 
     // Reset the results json cache.
-    this.resultsJson = null;
+    this.results = null;
   }
 }
 

--- a/src/connectors/multi-connector.js
+++ b/src/connectors/multi-connector.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const assert = require('../utils/assert');
+const Connector = require('./connector');
+
+/**
+ * the connector handles read and write actions with local JSON files as a data
+ * store. This connector works together with `src/helpers/node-helper.js`.
+ */
+class MultiConnector extends Connector {
+  constructor(config, apiHandler, testsConnector, resultsConnector) {
+    super(config, apiHandler);
+    this.apiHandler = apiHandler;
+
+    this.testsConnector = testsConnector;
+    this.resultsConnector = resultsConnector;
+  }
+
+  getEnvVars() {
+    return this.testsConnector.getEnvVars();
+  }
+
+  getTestList(options) {
+    return this.testsConnector.getTestList(options);
+  }
+
+  updateTestList(newTests, options) {
+    return this.testsConnector.updateTestList(newTests, options);
+  }
+
+  getResultList(options) {
+    return this.resultsConnector.getResultList(options);
+  }
+
+  appendResultList(newResults, options) {
+    return this.resultsConnector.appendResultList(newResults, options);
+  }
+
+  updateResultList(newResults, options) {
+    return this.resultsConnector.updateResultList(newResults, options);
+  }
+}
+
+module.exports = MultiConnector;

--- a/test/awp-core.test.js
+++ b/test/awp-core.test.js
@@ -181,11 +181,19 @@ describe('AutoWebPerf with fake modules', () => {
   let awp;
 
   beforeEach(() => {
-    awp = new AutoWebPerf({
-      connector: 'fake',
+    let awpConfig = {
+      tests: {
+        connector: 'fake',
+        path: 'fake/path'
+      },
+      results: {
+        connector: 'fake',
+        path: 'fake/path'
+      },
       helper: 'fake',
       gatherers: ['fake'],
-    });
+    };
+    awp = new AutoWebPerf(awpConfig);
     awp.connector = new FakeConnector();
     awp.apiHandler = fakeApiHandler;
     awp.gatherers = {
@@ -514,38 +522,5 @@ describe('AutoWebPerf with fake modules', () => {
     };
     errors = awp.getOverallErrors(result);
     expect(errors.length).toBe(0);
-  });
-});
-
-describe('AutoWebPerf with multiple connectors', () => {
-  let awp;
-
-  beforeEach(() => {
-    awp = new AutoWebPerf({
-      connector: {
-        tests: 'fake',
-        results: 'fake'
-      },
-      helper: 'fake',
-      gatherers: ['fake'],
-    });
-    awp.apiHandler = fakeApiHandler;
-    awp.gatherers = {
-      fake: new FakeGatherer(),
-    }
-    awp.extensions = {
-      fake: new FakeExtension(),
-    };
-
-    // Mock functions
-    ['beforeRun', 'afterRun', 'beforeRetrieve', 'afterRetrieve',
-        'beforeAllRuns', 'afterAllRuns', 'beforeAllRetrieves',
-        'afterAllRetrieves'].forEach(funcName => {
-          awp.extensions.fake[funcName] = jest.fn();
-        });
-  });
-
-  it('initializes normally.', async () => {
-    expect(awp).not.toBe(null);
   });
 });

--- a/test/connectors/appscript-connector.test.js
+++ b/test/connectors/appscript-connector.test.js
@@ -217,7 +217,7 @@ describe('AppScriptConnector EnvVars tab', () => {
   beforeEach(() => {
     // Overrides properties for testing.
     fakeSheets['EnvVars'] = initFakeSheet(fakeSheetData.fakeEnvVarsSheetData);
-    connector = new AppScriptConnector(connectorConfig, {} /* apiHelper */);
+    connector = new AppScriptConnector(connectorConfig, {} /* apiHandler */);
   });
 
   it('returns list of envVars values from the EnvVars sheet', async () => {
@@ -246,7 +246,7 @@ describe('AppScriptConnector Tests tab', () => {
     // Overrides properties for testing.
     fakeSheets['Tests-1'] = initFakeSheet(fakeSheetData.fakeTestsSheetData);
     fakeSheets['Tests-2'] = initFakeSheet(fakeSheetData.fakeTestsSheetData);
-    connector = new AppScriptConnector(connectorConfig, {} /* apiHelper */);
+    connector = new AppScriptConnector(connectorConfig, {} /* apiHandler */);
   });
 
   it('returns all tests from the Tests sheet', async () => {
@@ -313,7 +313,7 @@ describe('AppScriptConnector Tests tab', () => {
 describe('AppScriptConnector Results tab', () => {
   beforeEach(() => {
     fakeSheets['Results-1'] = initFakeSheet(fakeSheetData.fakeResultsSheetData);
-    connector = new AppScriptConnector(connectorConfig, {} /* apiHelper */);
+    connector = new AppScriptConnector(connectorConfig, {} /* apiHandler */);
   });
 
   it('returns list of results from the Results sheet', async () => {
@@ -564,7 +564,7 @@ describe('AppScriptConnector System tab', () => {
   beforeEach(() => {
     // Overrides properties for testing.
     fakeSheets['System'] = initFakeSheet(fakeSheetData.fakeSystemSheetData);
-    connector = new AppScriptConnector(connectorConfig, {} /* apiHelper */);
+    connector = new AppScriptConnector(connectorConfig, {} /* apiHandler */);
   });
 
   it('returns a specific system variable from the System sheet', async () => {
@@ -583,11 +583,11 @@ describe('AppScriptConnector Locations tab', () => {
   beforeEach(() => {
     // Overrides properties for testing.
     fakeSheets['Locations'] = initFakeSheet(fakeSheetData.fakeLocationsSheetData);
-    connector = new AppScriptConnector(connectorConfig, {} /* apiHelper */);
+    connector = new AppScriptConnector(connectorConfig, {} /* apiHandler */);
   });
 
   it('updates locations to LocationsTab', async () => {
-    connector.apiHelper.fetch = () => {
+    connector.apiHandler.fetch = () => {
       return {
         statusCode: 200,
         body: JSON.stringify({
@@ -634,7 +634,7 @@ describe('AppScriptConnector additional functions', () => {
     fakeSheets['System'] = initFakeSheet(fakeSheetData.fakeSystemSheetData);
     fakeSheets['Tests-1'] = initFakeSheet(fakeSheetData.fakeTestsSheetData);
     fakeSheets['Results-1'] = initFakeSheet(fakeSheetData.fakeResultsSheetData);
-    connector = new AppScriptConnector(connectorConfig, {} /* apiHelper */);
+    connector = new AppScriptConnector(connectorConfig, {} /* apiHandler */);
   });
 
   it('returns property lookup values for sheet with DataAxis.ROW', async () => {


### PR DESCRIPTION
The previous PR has flaw for multiple connectors when there are custom implementation in a specific connector. Adding a MultiConnector as the bridge to maintain the individual connector's internal logics.
- Added MultiConnector class to bridge two connectors.
- Added CSVConnector to read/write to csv files.
- Updated awpConfig with 'tests' and 'results' mandatory properties to 
specify connector and source path.
- Standardized other connectors.