### PR TITLE
Url connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ To run tests and override existing results in the output file
 ./awp run examples/tests.json output/results.json --override-results
 ```
 
+Alternatively, to run a single test with a specific URL:
+```
+./awp run --gatherer=psi url:https://web.dev json:output/results.json
+```
+
 ### Using AWP with Node CLI
 
 #### Run tests

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To run tests and override existing results in the output file
 
 Alternatively, to run a single test with a specific URL:
 ```
-./awp run --gatherer=psi url:https://web.dev json:output/results.json
+./awp run --gatherers=psi url:https://web.dev json:output/results.json
 ```
 
 ### Using AWP with Node CLI

--- a/integration/appscript-bundle.test.js
+++ b/integration/appscript-bundle.test.js
@@ -62,7 +62,6 @@ describe('AWP bundle for AppScript', () => {
         connector: 'appscript',
       },
       helper: 'appscript',
-      gatherers: [],
       extensions: [
         'budgets',
         'appscript',

--- a/src/cli.js
+++ b/src/cli.js
@@ -73,6 +73,9 @@ Examples:
   # Run tests and override existing results in the output file.
   ./awp run examples/tests.json output/results.json --override-results
 
+  # Run a single test with a specific URL via URL-Connector.
+  ./awp run --gatherer=psi url:https://web.dev json:output/results.json
+
   # Run with a custom awpConfig.
   ./awp run --config=examples/awp-config.json
 
@@ -158,7 +161,6 @@ async function begin() {
         path: resultsPath,
       },
       helper: 'node',
-      gatherers: gatherers || ['webpagetest', 'psi', 'cruxbigquery', 'cruxapi'],
       extensions: extensions,
       envVars: envVars,
       verbose: verbose,
@@ -179,6 +181,7 @@ async function begin() {
     runByBatch: runByBatch,
     overrideResults: overrideResults,
     timerInterval: timerInterval,
+    gatherer: gatherers,
     verbose: verbose,
     debug: debug,
   };

--- a/src/cli.js
+++ b/src/cli.js
@@ -74,7 +74,7 @@ Examples:
   ./awp run examples/tests.json output/results.json --override-results
 
   # Run a single test with a specific URL via URL-Connector.
-  ./awp run --gatherer=psi url:https://web.dev json:output/results.json
+  ./awp run --gatherers=psi url:https://web.dev json:output/results.json
 
   # Run with a custom awpConfig.
   ./awp run --config=examples/awp-config.json

--- a/src/connectors/url-connector.js
+++ b/src/connectors/url-connector.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const assert = require('../utils/assert');
+const setObject = require('../utils/set-object');
+const Connector = require('./connector');
+
+/**
+ * the connector handles read and write actions with local JSON files as a data
+ * store. This connector works together with `src/helpers/node-helper.js`.
+ * 
+ * Usage example:
+ * 
+ * ./awp run --gatherer=psi url:https://web.dev json:output/results.json
+ */
+class URLConnector extends Connector {
+  constructor(config, apiHandler, envVars) {
+    super(config, apiHandler, envVars);
+  }
+  
+  /**
+   * Get all tests.
+   * @param  {Object} options
+   * @return {Array<Object>} Array of Test objects.
+   */
+  getTestList(options) {
+    return [{
+      label: this.testsPath,
+      url: this.testsPath,
+      gatherer: options.gatherer || 'psi',
+    }];
+  }
+  
+  getEnvVars() {}
+  updateTestList(newTests, options) {}
+  getResultList(options) {}
+  appendResultList(newResults, options) {}
+  updateResultList(newResults, options) {}
+}
+
+module.exports = URLConnector;


### PR DESCRIPTION
Added URL connector for a quickest command to run a test for a URL.
For example:

/awp run --gatherers=psi url:https://web.dev json:output/results.json

This will generate the result for web.dev using PSI gatherer.