### PR TITLE
Publishing to stable 0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,46 @@ WPT_APIKEY=SAMPLE_KEY ./awp run examples/tests-wpt.json output/results.json
 ./awp run examples/tests.json output/results.json --override-results
 ```
 
-### Using AWP with Node CLI
+### Available gatherers:
 
-#### Run tests
+- WebPageTest - See [docs/webpagetest.md](docs/webpagetest.md) for details.
+- PageSpeed Insights - See [docs/psi.md](docs/psi.md) for details.
+- Chrome UX Report API - See [docs/cruxapi.md](docs/cruxapi.md) for details.
+- Chrome UX Report BigQuery - See [docs/cruxbigquery.md](docs/cruxbigquery.md) for details.
+
+### Available connectors:
+
+- JSON connector - reads or writes to local JSON files.
+This is the default connector if a conenctor name is not specified. For example:
+```
+./awp run examples/tests.json output/results.json
+```
+
+Alternatively, to specify using the JSON connector for the `Tests` path and the `Results` path:
+```
+./awp run json:/examples/tests.json json:output/results.json
+```
+
+- CSV connector - reads or writes to local CSV files.
+To specify using the CSV connector for the `Tests` path and the `Results` path:
+```
+./awp run csv:/examples/tests.csv csv:output/results.csv
+```
+
+- URL connector - generates just one `Test` with a specific URL for audit.
+To run an audit with just one `Test` with a specific URL:
+```
+./awp run url:https://example.com csv:output/results.csv
+```
+
+Please note that this connector only works with `Tests` path, not for the `Results` path.
+
+- Google Sheets connector
+See [docs/sheets-connector.md](docs/sheets-connector.md) for detailed guidance.
+
+## Using AWP with Node CLI
+
+### Run tests
 
 You can run the following anytime for printing CLI usages:
 
@@ -134,7 +171,7 @@ E.g. to run tests defined in CSV and write results in JSON:
 ./awp run csv:examples/tests.csv json:output/results.csv
 ```
 
-#### Retrieve test results
+### Retrieve test results
 
 For some audit platforms like WebPageTest, each test may take a few minutes to
 fetch actual results. For these type of *asynchronous* audits, each Result will
@@ -151,7 +188,7 @@ This will fetch metrics for all audit platforms and update to the Result object
 in the `output/results.json`. You can check out `examples/results.json` for
 details in Result objects.
 
-#### Run recurring tests
+### Run recurring tests
 
 If you'd like to set up recurring tests, you can define the `recurring` object
 that contains `frequency` for that Test.
@@ -186,7 +223,7 @@ The `nextTriggerTimestamp` will be updated to the next day based on the previous
 timestamp. This is to prevent repeated runs with the same Test and to guarantee
 that this Test is executed only once per day.
 
-#### Set up a cron job to run recurring tests
+### Set up a cron job to run recurring tests
 
 In most Unix-like operating system, you can set up a cron job to run the AWP CLI
 periodically.
@@ -206,7 +243,7 @@ that this is based on the system time where it runs AWP.
 0 12 * * * PSI_APIKEY=SAMPLE_KEY cd ~/workspace/awp && ./awp run examples/tests.json csv:output/results-recurring.csv
 ```
 
-#### Run tests with extensions
+### Run tests with extensions
 
 An extension is a module to assist AWP to run tests with additional process and
 computation. For example, `budgets` extension is able to add performance budgets
@@ -276,7 +313,13 @@ WebPageTest and PageSpeedInsights. See the example below.
 
 ### Environmental Variables
 
-TBD
+Some conenctors or gatherers may require one or more environmental variables, such as API keys or the path to 
+service account. For example, running with the CrUX API gatherer requires the CrUX API key.
+
+To pass the environmental variables in the CLI, run the command with the regular usage of environment vars:
+```
+CRUX_APIKEY=<YOUR_KEY> ./awp run url:https://wev.dev/ json:output/results.json
+```
 
 ## Gatherers
 
@@ -300,11 +343,16 @@ See [docs/psi.md](docs/psi.md) for more details for the usage of PSI gatherer.
 
 #### Chrome UX Report API (CrUX API)
 
-TBD
+The CrUX API gatherer collects performance metrics through the [Chrome UX Report API](https://developers.google.com/web/tools/chrome-user-experience-report/api/guides/getting-started). 
+
+See [docs/cruxapi.md](docs/cruxapi.md) for more details for the usage of CrUX API gatherer.
 
 #### Chrome UX Report History (CrUX via BigQuery)
 
-TBD
+The CrUX BigQuery gatherer collects performance metrics through the [Chrome UX Report](https://developers.google.com/web/tools/chrome-user-experience-report) with its [public Google BigQuery project](https://bigquery.cloud.google.com/dataset/chrome-ux-report:all). 
+Please noet that you would need set up a Google Cloud project in order to query the public BigQuery table.
+
+See [docs/cruxbigquery.md](docs/cruxbigquery.md) for more details for the usage of CrUX API gatherer.
 
 ## Design
 

--- a/docs/cruxapi.md
+++ b/docs/cruxapi.md
@@ -1,0 +1,94 @@
+# CrUX API Gatherer
+
+## Overview
+
+For more details in the Chrome UX Report API, please check out
+[the official documentation](https://developers.google.com/web/tools/chrome-user-experience-report/api/guides/getting-started).
+
+Below is a sample `Test` with `cruxapi` property that defines the
+configuration for running a WebPageTest audit.
+
+```
+{
+  "label": "Example",
+  "url": "https://examples.com",
+  "gatherer": "cruxapi",
+  "cruxapi": {
+    "settings": {
+      "urlType" : "Page",
+      "formFactor": "ALL"
+    }
+  }
+}
+```
+
+## Required Environmental Variables
+
+- `CRUX_APIKEY` - The API Key to access CrUX API endpoint. See [the official doc](https://developers.google.com/web/tools/chrome-user-experience-report/api/guides/getting-started) for details.
+
+## Audit Lifecycle
+
+CrUX API returns the metrics immediately after executing `run` action. Hence, 
+there's no need to execute `retrieve` step.
+
+Optionally, you may want to re-retrieve the metrics to a `Result` object by
+executing `retrieve` action.
+
+## Configuration details
+
+- `settings` <Object>: The settings is an object that defines a list of
+parameters for running a CrUX API audit. See the following parameters for details.
+- `settings.urlType` <string>: Specify `Page` or `Origin` to determine the CrUX metric level.
+- `settings.formFactor` <string>: The analysis strategy to use: `desktop` or
+`mobile`.
+with comma.
+
+## Run a Test and retrieve Metrics
+
+After running, the `cruxapi` object in a `Result` object will
+contain the `metrics` object and its corresponding values, like below:
+
+```
+{
+  "label": "Example",
+  "url": "https://examples.com",
+  "status": "Retrieved",  
+  "cruxapi": {
+    "status": "Retrieved",
+    "statusText": "Success",
+    "metrics": {
+      "LargestContentfulPaint": {
+        "p75": 2641,
+        "good": 0.7142390594382795,
+        "ni": 0.193990855649903,
+        "poor": 0.09177008491182273
+      },
+      "FirstInputDelay": {
+        "p75": 63,
+        "good": 0.8021015761821326,
+        "ni": 0.1429509632224161,
+        "poor": 0.05494746059544616
+      },
+      "CumulativeLayoutShift": {
+        "p75": "0.44",
+        "good": 0.654765332565504,
+        "ni": 0.03224877627411453,
+        "poor": 0.31298589116037934
+      },
+      "FirstContentfulPaint": {
+        "p75": 2742,
+        "good": 0.06867761917586854,
+        "ni": 0.732022623215728,
+        "poor": 0.19929975760840518
+      }
+    },
+    "settings": {
+      "urlType": "Page",
+      "formFactor": "PHONE"
+    },
+    "errors": []
+  }
+}
+```
+
+Please see [Chrome UX Report API docs](https://developers.google.com/web/tools/chrome-user-experience-report/api/guides/getting-started) for full details of the metric definitions.

--- a/docs/cruxbigquery.md
+++ b/docs/cruxbigquery.md
@@ -1,0 +1,112 @@
+# CrUX BigQuery Gatherer
+
+## Overview
+
+For more details in the Chrome UX Report, please check out
+[the official documentation](https://developers.google.com/web/tools/chrome-user-experience-report).
+
+Below is a sample `Test` with `cruxapi` property that defines the
+configuration for running a WebPageTest audit.
+
+```
+{
+  "label": "Example",
+  "origin": "https://example.com",
+  "gatherer": "cruxbigquery"
+}
+```
+
+Please note that CrUX BigQuery API is required to fetch results in `batch` mode. Please
+make sure to add the `--batch-mode` parameter when executing it via the CLI. For example:
+
+```
+./awp run json:examples/tests-cruxbigquery.json json:output/results.json --batch-mode
+```
+
+## Required Environmental Variables
+
+- `GCP_PROJECT_ID` - The Google Cloud unique project ID. See [the official doc](https://cloud.google.com/resource-manager/docs/creating-managing-projects) for creating a GCP project.
+- `SERVICE_ACCOUNT_CREDENTIALS` - The path to the Service Account json file.
+
+## Audit Lifecycle
+
+CrUX BigQuery API returns the metrics immediately after executing `run` action. Hence, 
+there's no need to execute `retrieve` step. Optionally, you may want to re-retrieve the 
+metrics to a `Result` object by executing `retrieve` action.
+
+## Configuration details
+
+- `origin` <string>: CrUX BigQuery gatherer takes `origin` in a `Test` instead of `url`. Please note that the 
+origin should start with a protocol, e.g. https://. See 
+
+## Run a Test and retrieve Metrics
+
+After running, the `cruxbigquery` object in a `Result` object will
+contain the `metrics` object and its corresponding values, like below:
+
+```
+{
+  "label": "Example",
+  "origin": "https://example.com",
+  "status": "Retrieved",  
+  "cruxbigquery": {
+    "status": "Retrieved",
+    "origin": "https://example.com",
+    "metrics": [
+      {
+        "Date": 201911,
+        "Origin": "https://example.com",
+        "Device": "desktop",
+        "p75_ttfb": 700,
+        "p75_fp": 1300,
+        "p75_fcp": 1300,
+        "p75_lcp": 1600,
+        "p75_fid": 0,
+        "p75_cls": "0.05",
+        "p75_dcl": 1600,
+        "p75_ol": 2600,
+        "fast_fp": 0.5394573064475977,
+        "avg_fp": 0.41921832213094345,
+        "slow_fp": 0.0413243714214588,
+        "fast_fcp": 0.785305105853051,
+        "avg_fcp": 0.14919053549190536,
+        "slow_fcp": 0.06550435865504359,
+        "fast_lcp": 0.9038031319910513,
+        "avg_lcp": 0.06062639821029082,
+        "slow_lcp": 0.03557046979865772,
+        "fast_fid": 0.9914021164021164,
+        "avg_fid": 0.006393298059964726,
+        "slow_fid": 0.002204585537918871,
+        "fast_dcl": 0.6841195356878241,
+        "avg_dcl": 0.27265991602864903,
+        "slow_dcl": 0.0432205482835268,
+        "fast_ol": 0.7125312713213555,
+        "avg_ol": 0.2572208323857176,
+        "slow_ol": 0.030247896292926995,
+        "fast_ttfb": 0.5149856658848059,
+        "avg_ttfb": 0.4289809747198332,
+        "slow_ttfb": 0.05603335939536096,
+        "small_cls": 0.7818437719915552,
+        "medium_cls": 0.15435139573070605,
+        "large_cls": 0.06380483227773867,
+        "desktopDensity": 0.4015,
+        "phoneDensity": 0,
+        "tabletDensity": 0,
+        "_4GDensity": 0.3854,
+        "_3GDensity": 0.0161,
+        "_2GDensity": 0,
+        "slow2GDensity": 0,
+        "offlineDensity": 0,
+        "notification_permission_accept": null,
+        "notification_permission_deny": null,
+        "notification_permission_ignore": null,
+        "notification_permission_dismiss": null
+      },
+      ...
+    ],
+    "errors": []
+  }
+}
+```
+
+Please see [Chrome UX Report API docs](https://developers.google.com/web/tools/chrome-user-experience-report/api/guides/getting-started) for full details of the metric definitions.

--- a/docs/psi.md
+++ b/docs/psi.md
@@ -12,6 +12,7 @@ configuration for running a WebPageTest audit.
 {
   "label": "Example",
   "url": "https://examples.com",
+  "gatherer": "psi",
   "psi": {
     "settings": {
       "locale": "en-GB",

--- a/docs/webpagetest.md
+++ b/docs/webpagetest.md
@@ -12,6 +12,7 @@ configuration for running a WebPageTest audit.
 {
   "label": "Example",
   "url": "https://example.com",
+  "gatherer": "webpagetest",
   "webpagetest": {
     "settings": {
       "locationId": "Dulles_MotoG",
@@ -26,6 +27,11 @@ configuration for running a WebPageTest audit.
   }
 }
 ```
+
+## Required Environmental Variables
+
+- `GCP_PROJECT_ID` - The project unique ID in the Google Cloud Platform. 
+- `SERVICE_ACCOUNT_CREDENTIALS` - The path to the Service Account json file.
 
 ## Audit Lifecycle
 

--- a/examples/tests-cruxbigquery.json
+++ b/examples/tests-cruxbigquery.json
@@ -1,8 +1,4 @@
 {
-  "envVars": {
-    "GCP_KEYFILE_PATH": "tmp/gcp-service-account.json",
-    "GCP_PROJECT_ID": "YOUR_GCP_PROJECT_ID"
-  },
   "tests": [
     {
       "label":"Web.dev no Protocol",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "AutoWebPerf",
   "main": "index.js",
   "scripts": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -36,7 +36,7 @@ Mandatory arguments:
 Options (*denotes default value if not passed in):
   gatherers\t\ttComma-separated list of data sources. Default: psi.
   extensions\t\tComma-separated list of extensions. Default: null.
-  config\t\tLoad a custom awpConfig. See examples/awp-config.json for example.
+  config\t\tLoad a custom awpConfig. See examples/awp-config.json for example. If the config parameter is given, the tests and results parameters will be ignored.
   override-results\tWhether to append results to the existing result list. Default: false.
   timer-interval\tSet the timer interval for executing recurring continuously.
   verbose\t\tPrint out verbose logs.
@@ -125,8 +125,8 @@ async function begin() {
     envVars[key] = envVarsFromParam[key];
   });
 
-  // Assert mandatory parameters
-  if (!action || !testsPath || !resultsPath) {
+  // Assert mandatory parameters, except if the config is given.
+  if (!config && (!action || !testsPath || !resultsPath)) {
     printUsage();
     return;
   }

--- a/src/connectors/sheets-connector.js
+++ b/src/connectors/sheets-connector.js
@@ -118,7 +118,7 @@ class SheetsConnector extends Connector {
   }
 
   async updateSheetData(sheet, newObjs) {
-    newObjs = this.stringifyArray(newObjs);    
+    newObjs = this.stringifyRows(newObjs);    
     await this.updateHeaders(sheet, newObjs);
     const rows = await sheet.getRows();
 
@@ -188,8 +188,13 @@ class SheetsConnector extends Connector {
     results.forEach(result => {
       rowsToAdd.push(flattenObject(result));
     });
-    rowsToAdd = this.stringifyArray(rowsToAdd);    
+    rowsToAdd = this.stringifyRows(rowsToAdd);    
     await this.updateHeaders(sheet, rowsToAdd);
+
+    if (this.debug) {
+      console.log('rowsToAdd:');
+      console.log(rowsToAdd);
+    }
 
     if (this.verbose) {
       console.log(`Adding ${rowsToAdd.length} rows to result sheet.`);
@@ -346,11 +351,11 @@ class SheetsConnector extends Connector {
     });
   }
 
-  stringifyArray(objs) {
+  stringifyRows(objs) {
     return objs.map(obj => {
       let newObj = {};
       for (const [key, value] of Object.entries(obj)) {
-        obj[key] = Array.isArray(value) ? value.toString() : value;
+        obj[key] = !['number', 'string'].includes(typeof value) ? JSON.stringify(value) : value;
       }
       return obj;
     });

--- a/src/gatherers/cruxbigquery.js
+++ b/src/gatherers/cruxbigquery.js
@@ -29,11 +29,10 @@ class CrUXBigQueryGatherer extends Gatherer {
     assert(apiHandler, 'Parameter apiHandler is missing.');
 
     this.gcpProjectId = envVars.GCP_PROJECT_ID || envVars.gcpProjectId;
-    this.keyFilename = envVars.GCP_KEYFILE_PATH || envVars.gcpKeyFilePath;
+    this.keyFilename = envVars.SERVICE_ACCOUNT_CREDENTIALS || envVars.GCP_KEYFILE_PATH || envVars.gcpKeyFilePath;
 
     assert(this.gcpProjectId, 'gcpProjectId is not defined in Environment ' +
         'Variables');
-
     this.bigQueryHandler = new BigQueryHandler({
       platform: config.platform || 'Node',
       projectId: this.gcpProjectId,


### PR DESCRIPTION
Multiple fixes:
#35 - Fixed the CLI with config parameter, without the need to pass tests and results path.
#37 - Fixed the PSI gatherer with Sheets connector, with non-string or non-number values.