### PR TITLE
Remove `lighthouseResult.audits["works-offline"].score`

### DIFF
--- a/docs/psi.md
+++ b/docs/psi.md
@@ -22,6 +22,14 @@ configuration for running a WebPageTest audit.
 }
 ```
 
+## Optional Environmental Variables
+
+- `PSI_APIKEY` - Use an API Key to relax rate limiting, for example if you see an error like:
+
+> Quota exceeded for quota metric 'Queries' and limit 'Queries per minute' of service 'pagespeedonline.googleapis.com' for consumer 'project_number:nnnn'."
+
+See [the official doc](https://developers.google.com/speed/docs/insights/v5/get-started#key) for details.
+
 ## Audit Lifecycle
 
 PageSpeed Insights API returns the metrics immediately after executing `run`

--- a/src/gatherers/psi.js
+++ b/src/gatherers/psi.js
@@ -76,7 +76,6 @@ class PSIGatherer extends Gatherer {
       'lighthouse.ProgressiveWebApp': 'lighthouseResult.categories.pwa.score',
       'lighthouse.Manifest': 'lighthouseResult.audits["installable-manifest"].score',
       'lighthouse.ServiceWorker': 'lighthouseResult.audits["service-worker"].score',
-      'lighthouse.Offline': 'lighthouseResult.audits["works-offline"].score',
       'lighthouse.Accessibility': 'lighthouseResult.categories.accessibility.score',
       'lighthouse.SEO': 'lighthouseResult.categories.seo.score',
       'lighthouse.BestPractices': 'lighthouseResult.categories["best-practices"].score',


### PR DESCRIPTION
Remove `lighthouseResult.audits["works-offline"].score`, which was removed upstream in: https://github.com/GoogleChrome/lighthouse/pull/11806

Fixes #46 

(sorry for the re-post - had a typo in the previous PR!)
