### PR TITLE
Fix PSI metric name changes: modern-image-formats and installable-manifest

### DIFF
--- a/src/gatherers/psi.js
+++ b/src/gatherers/psi.js
@@ -66,7 +66,7 @@ class PSIGatherer extends Gatherer {
       'lighthouse.Medias': 'processedRessourceSummaryItems.MediasSize',
       'lighthouse.ThirdParty': 'processedRessourceSummaryItems.ThirdPartySize',
       'lighthouse.UnusedCSS': 'lighthouseResult.audits["unused-css-rules"].details.overallSavingsBytes',
-      'lighthouse.WebPImages': 'lighthouseResult.audits["uses-webp-images"].details.overallSavingsBytes',
+      'lighthouse.WebPImages': 'lighthouseResult.audits["modern-image-formats"].details.overallSavingsBytes',
       'lighthouse.OptimizedImages': 'lighthouseResult.audits["uses-optimized-images"].details.overallSavingsBytes',
       'lighthouse.ResponsiveImages': 'lighthouseResult.audits["uses-responsive-images"].details.overallSavingsBytes',
       'lighthouse.OffscreenImages': 'lighthouseResult.audits["offscreen-images"].details.overallSavingsBytes',


### PR DESCRIPTION
This will fix [issue 57 ](https://github.com/GoogleChromeLabs/AutoWebPerf/issues/57) with the outdated metrics mapping
- modern-image-formats