### PR TITLE
Updated npm package name to autowebperf for npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "awp",
+  "name": "autowebperf",
   "version": "0.3.2",
   "description": "AutoWebPerf",
   "main": "index.js",


### PR DESCRIPTION
`awp` is already taken, hence changing the package name to `autowebperf`