### PR TITLE
Adding automatic NPM publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,25 @@
+name: npm-publish
+on:
+  push:
+    branches:
+      - stable # Change this to your default branch
+jobs:
+  npm-publish:
+    name: npm-publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Publish if version has been updated
+      uses: pascalgn/npm-publish-action@1.3.8
+      with: # All of theses inputs are optional
+        tag_name: "v%s"
+        tag_message: "v%s"
+        create_tag: "true"
+        commit_pattern: "^Release (\\S+)"
+        workspace: "."
+        publish_command: "yarn"
+        publish_args: "--non-interactive"
+      env: # More info about the environment variables in the README
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # You need to set this in your repo settings


### PR DESCRIPTION
- This is to add an automatic Github action to publish NPM package when a push merged to `stable` branch.
- This uses the NPM profile as https://www.npmjs.com/~jonchen
- The NPM token is stored in this repo's secret. Please use it with caution.